### PR TITLE
Provide option to clone using ssh auth instead of https

### DIFF
--- a/src/pipeline/issue.py
+++ b/src/pipeline/issue.py
@@ -113,12 +113,17 @@ def get_branch_id(issue):
     return f"issue-{issue.id}"
 
 
-def prepare_branch(issue: Issue, dry_run: bool) -> None:
+def prepare_branch(issue: Issue, dry_run: bool, url_type: str = "https") -> None:
     target_dir = get_target_dir(issue)
     if os.path.exists(target_dir):
         shutil.rmtree(target_dir, ignore_errors=True)
     os.makedirs(target_dir, exist_ok=True)
-    repo.clone_repository(f"https://github.com/{issue.repository}.git", target_dir)
+    repo_url = (
+        f"https://github.com/{issue.repository}.git"
+        if url_type == "https"
+        else f"git@github.com:{issue.repository}.git"
+    )
+    repo.clone_repository(repo_url, target_dir)
     branch_id = get_branch_id(issue)
     if not dry_run:
         repo.switch_and_reset_branch(branch_id, target_dir)

--- a/src/settings.py
+++ b/src/settings.py
@@ -3,3 +3,4 @@ CODE_PATH = "src"
 GITIGNORE_PATH = ".gitignore"
 ADMIN_USERS = ["reitzensteinm"]
 TOKEN_LIMIT = 40000
+URL_TYPE = "https"


### PR DESCRIPTION
modify the prepare_branch function to have the option of using ssh github repo URLs instead of just https ones, configurable in settings.py and defaulting to https.